### PR TITLE
Support Ingress v1 and k8s 1.19+ features

### DIFF
--- a/deploy-etchosts-daemonset.yml
+++ b/deploy-etchosts-daemonset.yml
@@ -19,6 +19,13 @@ spec:
         - image: compumike/hairpin-proxy-controller:0.2.1
           name: main
           command: ["/app/src/main.rb", "--etc-hosts", "/app/etchosts"]
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: hairpin-proxy
           volumeMounts:
             - name: etchosts
               mountPath: /app/etchosts

--- a/deploy.yml
+++ b/deploy.yml
@@ -152,6 +152,13 @@ spec:
         runAsGroup: 65533
       containers:
         - image: compumike/hairpin-proxy-controller:0.2.1
+          env:
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: hairpin-proxy
           name: main
           resources:
             requests:


### PR DESCRIPTION
* Limit api calls to only Ingress v1. If v1beta1 run on k8s 1.22+, then it logs an error every POLL_INTERVAL but otherwise works. v1 only supported since 1.19, so allow configuring INGRESS_API_VERSION
* Add ability to deploy with configurable namespace and service name. This in a helm chart allows multiple instances linked to different IngressClasses
* Add ability to read hosts from the Ingress spec.rules.host configuration, as to allow ACME DNS01 wildcard domain verification to be used, and/or a default certificate not requiring spec.tls.hosts