### PR TITLE
Add multi-platform docker image build to quay.io with tags

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+    categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Implemented enhancements
+      labels:
+        - enhancement
+    - title: Fixed bugs
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,76 @@
+pipeline {
+    agent none
+    options {
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
+    }
+    triggers { cron(env.BRANCH_NAME ==~ /^master$/ ? 'H H(0-6) 1 * *' : '') }
+    stages {
+        stage('Matrix') {
+            matrix {
+                axes {
+                    axis {
+                        name 'PLATFORM'
+                        values 'linux-amd64', 'linux-arm64'
+                    }
+                }
+                environment {
+                    TAG_SUFFIX = "-${TAG_NAME ?: GIT_COMMIT}-${PLATFORM}"
+                }
+                stages {
+                    stage('Build, Test, Publish') {
+                        agent { label "${PLATFORM}" }
+                        stages {
+                            stage('Build') {
+                                steps {
+                                    sh 'docker compose build'
+                                }
+                            }
+                            stage('Publish') {
+                                environment {
+                                    DOCKER_REGISTRY_CREDS = credentials('docker-registry-credentials')
+                                }
+                                when {
+                                    buildingTag()
+                                }
+                                steps {
+                                    sh 'echo "$DOCKER_REGISTRY_CREDS_PSW" | docker login --username "$DOCKER_REGISTRY_CREDS_USR" --password-stdin docker.io'
+                                    sh 'docker compose push'
+                                }
+                                post {
+                                    always {
+                                        sh 'docker logout docker.io'
+                                    }
+                                }
+                            }
+                        }
+                        post {
+                            always {
+                                sh 'docker compose down -v --rmi all'
+                                cleanWs()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Publish main image') {
+            agent { label "linux-amd64" }
+            environment {
+                DOCKER_REGISTRY_CREDS = credentials('docker-registry-credentials')
+                TAG_SUFFIX = "-${TAG_NAME}"
+            }
+            when {
+                buildingTag()
+            }
+            steps {
+                sh './manifest-push.sh'
+            }
+            post {
+                always {
+                    sh 'docker logout docker.io'
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  controller:
+    image: quay.io/inviqa_images/hairpin-proxy:controller${TAG_SUFFIX}
+    build:
+      context: ./hairpin-proxy-controller
+      # Uncomment out this for development convenience.
+      #target: build
+  haproxy:
+    image: quay.io/inviqa_images/hairpin-proxy:haproxy${TAG_SUFFIX}
+    build:
+      context: ./hairpin-proxy-haproxy

--- a/hairpin-proxy-controller/Dockerfile
+++ b/hairpin-proxy-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine AS build
+FROM ruby:2.7.6-alpine AS build
 
 ENV GEM_HOME="/usr/local/bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
@@ -12,9 +12,7 @@ COPY Gemfile Gemfile.lock /app/
 WORKDIR /app/
 RUN bundle install --jobs 16 --retry 5
 
-# Comment out these four lines for development convenience.
-# Uncomment for a smaller container image.
-FROM ruby:2.7.2-alpine AS run
+FROM ruby:2.7.6-alpine AS run
 COPY --from=build $GEM_HOME $GEM_HOME
 COPY Gemfile Gemfile.lock /app/
 WORKDIR /app/

--- a/manifest-push.sh
+++ b/manifest-push.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+echo "${DOCKER_REGISTRY_CREDS_PSW}" | docker login --username "${DOCKER_REGISTRY_CREDS_USR}" --password-stdin docker.io
+
+for IMAGE in $(docker compose config --format json | jq -r '.services[].image'); do
+    docker manifest create "${IMAGE}" "${IMAGE}-linux-amd64" "${IMAGE}-linux-arm64"
+    docker manifest push "${IMAGE}"
+done


### PR DESCRIPTION
* multi-platform by default for future convenience and if fork is open-source
* git tags used for publishing images, for semver (e.g. pre-release in github then release when built)
* ruby updated to latest 2.7, which is in security maintenance till about April 2023